### PR TITLE
Fix podspec syntax

### DIFF
--- a/Unflow.podspec
+++ b/Unflow.podspec
@@ -10,8 +10,9 @@ Pod::Spec.new do |s|
     s.platform              = :ios
     s.swift_version         = '5.5'
     s.ios.deployment_target = '11.0'
-    s.vendored_frameworks   = 'UnflowUI.xcframework'
-    s.vendored_frameworks   = 'Unflow.xcframework'
+    s.vendored_frameworks   = 'UnflowUI.xcframework', 'Unflow.xcframework'
+
+    s.dependency 'Nuke'
 
     # Remove these once we have added arm64 simulator slices to our XCFramework
     s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }


### PR DESCRIPTION
* Fix vendored frameworks syntax
* Add Nuke dependency

App podifle should look like:
```
target 'UnflowCocoaPodsSample' do
  use_frameworks!

  pod 'Unflow', :git => 'https://github.com/unflowhq/unflow-ios-sdk.git', :tag => '1.0.0'
  pod 'Nuke', :git => 'https://github.com/kean/Nuke', :branch => 'master'
end
```