### PR TITLE
Add Sources/Unflow directory

### DIFF
--- a/Sources/Unflow/SPMTargetWrapper.swift
+++ b/Sources/Unflow/SPMTargetWrapper.swift
@@ -1,0 +1,1 @@
+// We need this empty Swift file as SPM requires there to be sources for our `UnflowTarget` – which is just a wrapper so that we can have binary targets with dependencies


### PR DESCRIPTION
We need to add a `Sources/Unflow` directory to match that for [UnflowTarget](https://github.com/unflowhq/unflow-ios-sdk/blob/main/Sources/UnflowTarget/SPMTargetWrapper.swift). It is empty but stops XCode throwing an error when integrating via Swift Package Manager