### PR TITLE
Update podspec to explicitly define a module

### DIFF
--- a/Unflow.podspec
+++ b/Unflow.podspec
@@ -11,4 +11,6 @@ Pod::Spec.new do |s|
     s.swift_version         = '5.5'
     s.ios.deployment_target = '11.0'
     s.vendored_frameworks   = 'UnflowUI.xcframework', 'Unflow.xcframework'
+    
+    s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 end


### PR DESCRIPTION
To avoid people manually having to add "use_frameworks! :linkage => :static", we can just explicitly state that Unflow defines a module.